### PR TITLE
Dummy KPU and APU and FFT

### DIFF
--- a/k210.svd
+++ b/k210.svd
@@ -876,6 +876,23 @@
         </peripheral>
         <!-- KPU -->
 
+        <!-- FFT -->
+        <peripheral>
+            <name>FFT</name>
+            <description>Fast Fourier Transform Accelerator</description>
+            <groupName>FFT</groupName>
+            <baseAddress>0x42000000</baseAddress>
+            <registers>
+                <!-- TODO -->
+                <register>
+                    <name>dummy</name>
+                    <description>Dummy register: this peripheral is not implemented yet</description>
+                    <addressOffset>0x00</addressOffset>
+                </register>
+            </registers>
+        </peripheral>
+        <!-- FFT -->
+
         <!-- DMAC -->
         <peripheral>
             <name>DMAC</name>

--- a/k210.svd
+++ b/k210.svd
@@ -859,6 +859,23 @@
         </peripheral>
         <!-- GPIOHS -->
 
+        <!-- KPU -->
+        <peripheral>
+            <name>KPU</name>
+            <description>Neural Network Accelerator</description>
+            <groupName>KPU</groupName>
+            <baseAddress>0x40800000</baseAddress>
+            <registers>
+                <!-- TODO -->
+                <register>
+                    <name>dummy</name>
+                    <description>Dummy register: this peripheral is not implemented yet</description>
+                    <addressOffset>0x00</addressOffset>
+                </register>
+            </registers>
+        </peripheral>
+        <!-- KPU -->
+
         <!-- DMAC -->
         <peripheral>
             <name>DMAC</name>
@@ -1667,6 +1684,23 @@
             </registers>
         </peripheral>
         <!-- I2S0 -->
+
+        <!-- APU -->
+        <peripheral>
+            <name>APU</name>
+            <description>Audio Processor</description>
+            <groupName>APU</groupName>
+            <baseAddress>0x50250200</baseAddress>
+            <registers>
+                <!-- TODO -->
+                <register>
+                    <name>dummy</name>
+                    <description>Dummy register: this peripheral is not implemented yet</description>
+                    <addressOffset>0x00</addressOffset>
+                </register>
+            </registers>
+        </peripheral>
+        <!-- APU -->
 
         <!-- I2S1 -->
         <peripheral derivedFrom="I2S0">

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -1,0 +1,12 @@
+#[doc = r" Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Dummy register: this peripheral is not implemented yet"]
+    pub dummy: DUMMY,
+}
+#[doc = "Dummy register: this peripheral is not implemented yet"]
+pub struct DUMMY {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "Dummy register: this peripheral is not implemented yet"]
+pub mod dummy;

--- a/src/apu/dummy.rs
+++ b/src/apu/dummy.rs
@@ -1,0 +1,64 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::DUMMY {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}

--- a/src/kpu.rs
+++ b/src/kpu.rs
@@ -1,0 +1,12 @@
+#[doc = r" Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Dummy register: this peripheral is not implemented yet"]
+    pub dummy: DUMMY,
+}
+#[doc = "Dummy register: this peripheral is not implemented yet"]
+pub struct DUMMY {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "Dummy register: this peripheral is not implemented yet"]
+pub mod dummy;

--- a/src/kpu/dummy.rs
+++ b/src/kpu/dummy.rs
@@ -1,0 +1,64 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::DUMMY {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,25 @@ impl Deref for KPU {
 }
 #[doc = "Neural Network Accelerator"]
 pub mod kpu;
+#[doc = "Fast Fourier Transform Accelerator"]
+pub struct FFT {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for FFT {}
+impl FFT {
+    #[doc = r" Returns a pointer to the register block"]
+    pub fn ptr() -> *const fft::RegisterBlock {
+        1107296256 as *const _
+    }
+}
+impl Deref for FFT {
+    type Target = fft::RegisterBlock;
+    fn deref(&self) -> &fft::RegisterBlock {
+        unsafe { &*FFT::ptr() }
+    }
+}
+#[doc = "Fast Fourier Transform Accelerator"]
+pub mod fft;
 #[doc = "Direct Memory Access Controller"]
 pub struct DMAC {
     _marker: PhantomData<*const ()>,
@@ -632,6 +651,8 @@ pub struct Peripherals {
     pub GPIOHS: GPIOHS,
     #[doc = "KPU"]
     pub KPU: KPU,
+    #[doc = "FFT"]
+    pub FFT: FFT,
     #[doc = "DMAC"]
     pub DMAC: DMAC,
     #[doc = "GPIO"]
@@ -719,6 +740,9 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             KPU: KPU {
+                _marker: PhantomData,
+            },
+            FFT: FFT {
                 _marker: PhantomData,
             },
             DMAC: DMAC {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,25 @@ impl Deref for GPIOHS {
 }
 #[doc = "High-speed GPIO"]
 pub mod gpiohs;
+#[doc = "Neural Network Accelerator"]
+pub struct KPU {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for KPU {}
+impl KPU {
+    #[doc = r" Returns a pointer to the register block"]
+    pub fn ptr() -> *const kpu::RegisterBlock {
+        1082130432 as *const _
+    }
+}
+impl Deref for KPU {
+    type Target = kpu::RegisterBlock;
+    fn deref(&self) -> &kpu::RegisterBlock {
+        unsafe { &*KPU::ptr() }
+    }
+}
+#[doc = "Neural Network Accelerator"]
+pub mod kpu;
 #[doc = "Direct Memory Access Controller"]
 pub struct DMAC {
     _marker: PhantomData<*const ()>,
@@ -270,6 +289,25 @@ impl Deref for I2S0 {
 }
 #[doc = "Inter-Integrated Sound Interface 0"]
 pub mod i2s0;
+#[doc = "Audio Processor"]
+pub struct APU {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for APU {}
+impl APU {
+    #[doc = r" Returns a pointer to the register block"]
+    pub fn ptr() -> *const apu::RegisterBlock {
+        1344602624 as *const _
+    }
+}
+impl Deref for APU {
+    type Target = apu::RegisterBlock;
+    fn deref(&self) -> &apu::RegisterBlock {
+        unsafe { &*APU::ptr() }
+    }
+}
+#[doc = "Audio Processor"]
+pub mod apu;
 #[doc = "Inter-Integrated Sound Interface 1"]
 pub struct I2S1 {
     _marker: PhantomData<*const ()>,
@@ -592,6 +630,8 @@ pub struct Peripherals {
     pub UARTHS: UARTHS,
     #[doc = "GPIOHS"]
     pub GPIOHS: GPIOHS,
+    #[doc = "KPU"]
+    pub KPU: KPU,
     #[doc = "DMAC"]
     pub DMAC: DMAC,
     #[doc = "GPIO"]
@@ -612,6 +652,8 @@ pub struct Peripherals {
     pub SPI3: SPI3,
     #[doc = "I2S0"]
     pub I2S0: I2S0,
+    #[doc = "APU"]
+    pub APU: APU,
     #[doc = "I2S1"]
     pub I2S1: I2S1,
     #[doc = "I2S2"]
@@ -676,6 +718,9 @@ impl Peripherals {
             GPIOHS: GPIOHS {
                 _marker: PhantomData,
             },
+            KPU: KPU {
+                _marker: PhantomData,
+            },
             DMAC: DMAC {
                 _marker: PhantomData,
             },
@@ -704,6 +749,9 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             I2S0: I2S0 {
+                _marker: PhantomData,
+            },
+            APU: APU {
                 _marker: PhantomData,
             },
             I2S1: I2S1 {


### PR DESCRIPTION
- KPU base address is `AI_BASE_ADDR` in `lib/bsp/include/platform.h`
- APU base address is `BEAFORMING_BASE_ADDR` in `lib/drivers/apu.c`
- FFT base address is `FFT_BASE_ADDR` in `lib/bsp/include/platform.h`