### PR TITLE
KPU

### DIFF
--- a/k210.svd
+++ b/k210.svd
@@ -865,12 +865,115 @@
             <description>Neural Network Accelerator</description>
             <groupName>KPU</groupName>
             <baseAddress>0x40800000</baseAddress>
+            <size>64</size>
             <registers>
-                <!-- TODO -->
                 <register>
-                    <name>dummy</name>
-                    <description>Dummy register: this peripheral is not implemented yet</description>
+                    <name>layer_argument_fifo</name>
+                    <description>Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register</description>
                     <addressOffset>0x00</addressOffset>
+                </register>
+                <register>
+                    <name>interrupt_status</name>
+                    <description>Interrupt status</description>
+                    <addressOffset>0x08</addressOffset>
+                    <fields>
+                        <field>
+                            <name>calc_done</name>
+                            <description>Interrupt raised when calculation is done</description>
+                            <bitRange>[0:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>layer_cfg_almost_empty</name>
+                            <description>Interrupt raised when layer arguments FIFO almost empty</description>
+                            <bitRange>[1:1]</bitRange>
+                        </field>
+                        <field>
+                            <name>layer_cfg_almost_full</name>
+                            <description>Interrupt raised when layer arguments FIFO almost full</description>
+                            <bitRange>[2:2]</bitRange>
+                        </field>
+                    </fields>
+                </register>
+                <register derivedFrom="interrupt_status">
+                    <name>interrupt_raw</name>
+                    <description>Interrupt raw</description>
+                    <addressOffset>0x10</addressOffset>
+                </register>
+                <register derivedFrom="interrupt_status">
+                    <name>interrupt_mask</name>
+                    <description>Interrupt mask: 0 enables the interrupt, 1 masks the interrupt</description>
+                    <addressOffset>0x18</addressOffset>
+                </register>
+                <register derivedFrom="interrupt_status">
+                    <name>interrupt_clear</name>
+                    <description>Interrupt clear: write 1 to a bit to clear interrupt</description>
+                    <addressOffset>0x20</addressOffset>
+                </register>
+                <register>
+                    <name>fifo_threshold</name>
+                    <description>FIFO threshold</description>
+                    <addressOffset>0x28</addressOffset>
+                    <fields>
+                        <field>
+                            <name>full</name>
+                            <description>FIFO full threshold</description>
+                            <bitRange>[3:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>empty</name>
+                            <description>FIFO empty threshold</description>
+                            <bitRange>[7:4]</bitRange>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>fifo_data_out</name>
+                    <description>FIFO data output</description>
+                    <addressOffset>0x30</addressOffset>
+                </register>
+                <register>
+                    <name>fifo_ctrl</name>
+                    <description>FIFO control</description>
+                    <addressOffset>0x38</addressOffset>
+                    <fields>
+                        <field>
+                            <name>dma_flush</name>
+                            <description>Flush DMA FIFO</description>
+                            <bitRange>[0:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>gs_flush</name>
+                            <description>Flush GS FIFO</description>
+                            <bitRange>[1:1]</bitRange>
+                        </field>
+                        <field>
+                            <name>cfg_flush</name>
+                            <description>Flush configuration FIFO</description>
+                            <bitRange>[2:2]</bitRange>
+                        </field>
+                        <field>
+                            <name>cmd_flush</name>
+                            <description>Flush command FIFO</description>
+                            <bitRange>[3:3]</bitRange>
+                        </field>
+                        <field>
+                            <name>resp_flush</name>
+                            <description>Flush response FIFO</description>
+                            <bitRange>[4:4]</bitRange>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>eight_bit_mode</name>
+                    <description>Eight bit mode</description>
+                    <addressOffset>0x40</addressOffset>
+                    <fields>
+                        <field>
+                            <name>eight_bit_mode</name>
+                            <description>Use 8-bit instead of 16-bit precision if set</description>
+                            <bitRange>[0:0]</bitRange>
+                        </field>
+                    </fields>
                 </register>
             </registers>
         </peripheral>

--- a/k210.svd
+++ b/k210.svd
@@ -865,17 +865,19 @@
             <description>Neural Network Accelerator</description>
             <groupName>KPU</groupName>
             <baseAddress>0x40800000</baseAddress>
-            <size>64</size>
+            <!-- TODO <size>64</size> -->
             <registers>
                 <register>
                     <name>layer_argument_fifo</name>
                     <description>Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register</description>
                     <addressOffset>0x00</addressOffset>
+                    <size>64</size>
                 </register>
                 <register>
                     <name>interrupt_status</name>
                     <description>Interrupt status</description>
                     <addressOffset>0x08</addressOffset>
+                    <size>64</size>
                     <fields>
                         <field>
                             <name>calc_done</name>
@@ -898,21 +900,25 @@
                     <name>interrupt_raw</name>
                     <description>Interrupt raw</description>
                     <addressOffset>0x10</addressOffset>
+                    <size>64</size>
                 </register>
                 <register derivedFrom="interrupt_status">
                     <name>interrupt_mask</name>
                     <description>Interrupt mask: 0 enables the interrupt, 1 masks the interrupt</description>
                     <addressOffset>0x18</addressOffset>
+                    <size>64</size>
                 </register>
                 <register derivedFrom="interrupt_status">
                     <name>interrupt_clear</name>
                     <description>Interrupt clear: write 1 to a bit to clear interrupt</description>
                     <addressOffset>0x20</addressOffset>
+                    <size>64</size>
                 </register>
                 <register>
                     <name>fifo_threshold</name>
                     <description>FIFO threshold</description>
                     <addressOffset>0x28</addressOffset>
+                    <size>64</size>
                     <fields>
                         <field>
                             <name>full</name>
@@ -930,11 +936,13 @@
                     <name>fifo_data_out</name>
                     <description>FIFO data output</description>
                     <addressOffset>0x30</addressOffset>
+                    <size>64</size>
                 </register>
                 <register>
                     <name>fifo_ctrl</name>
                     <description>FIFO control</description>
                     <addressOffset>0x38</addressOffset>
+                    <size>64</size>
                     <fields>
                         <field>
                             <name>dma_flush</name>
@@ -967,6 +975,7 @@
                     <name>eight_bit_mode</name>
                     <description>Eight bit mode</description>
                     <addressOffset>0x40</addressOffset>
+                    <size>64</size>
                     <fields>
                         <field>
                             <name>eight_bit_mode</name>

--- a/k210.svd
+++ b/k210.svd
@@ -921,12 +921,12 @@
                     <size>64</size>
                     <fields>
                         <field>
-                            <name>full</name>
+                            <name>full_threshold</name>
                             <description>FIFO full threshold</description>
                             <bitRange>[3:0]</bitRange>
                         </field>
                         <field>
-                            <name>empty</name>
+                            <name>empty_threshold</name>
                             <description>FIFO empty threshold</description>
                             <bitRange>[7:4]</bitRange>
                         </field>
@@ -945,27 +945,27 @@
                     <size>64</size>
                     <fields>
                         <field>
-                            <name>dma_flush</name>
+                            <name>dma_fifo_flush_n</name>
                             <description>Flush DMA FIFO</description>
                             <bitRange>[0:0]</bitRange>
                         </field>
                         <field>
-                            <name>gs_flush</name>
+                            <name>gs_fifo_flush_n</name>
                             <description>Flush GS FIFO</description>
                             <bitRange>[1:1]</bitRange>
                         </field>
                         <field>
-                            <name>cfg_flush</name>
+                            <name>cfg_fifo_flush_n</name>
                             <description>Flush configuration FIFO</description>
                             <bitRange>[2:2]</bitRange>
                         </field>
                         <field>
-                            <name>cmd_flush</name>
+                            <name>cmd_fifo_flush_n</name>
                             <description>Flush command FIFO</description>
                             <bitRange>[3:3]</bitRange>
                         </field>
                         <field>
-                            <name>resp_flush</name>
+                            <name>resp_fifo_flush_n</name>
                             <description>Flush response FIFO</description>
                             <bitRange>[4:4]</bitRange>
                         </field>

--- a/src/kpu.rs
+++ b/src/kpu.rs
@@ -1,12 +1,84 @@
 #[doc = r" Register block"]
 #[repr(C)]
 pub struct RegisterBlock {
-    #[doc = "0x00 - Dummy register: this peripheral is not implemented yet"]
-    pub dummy: DUMMY,
+    #[doc = "0x00 - Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register"]
+    pub layer_argument_fifo: LAYER_ARGUMENT_FIFO,
+    _reserved0: [u8; 4usize],
+    #[doc = "0x08 - Interrupt status"]
+    pub interrupt_status: INTERRUPT_STATUS,
+    _reserved1: [u8; 4usize],
+    #[doc = "0x10 - Interrupt raw"]
+    pub interrupt_raw: INTERRUPT_RAW,
+    _reserved2: [u8; 4usize],
+    #[doc = "0x18 - Interrupt mask: 0 enables the interrupt, 1 masks the interrupt"]
+    pub interrupt_mask: INTERRUPT_MASK,
+    _reserved3: [u8; 4usize],
+    #[doc = "0x20 - Interrupt clear: write 1 to a bit to clear interrupt"]
+    pub interrupt_clear: INTERRUPT_CLEAR,
+    _reserved4: [u8; 4usize],
+    #[doc = "0x28 - FIFO threshold"]
+    pub fifo_threshold: FIFO_THRESHOLD,
+    _reserved5: [u8; 4usize],
+    #[doc = "0x30 - FIFO data output"]
+    pub fifo_data_out: FIFO_DATA_OUT,
+    _reserved6: [u8; 4usize],
+    #[doc = "0x38 - FIFO control"]
+    pub fifo_ctrl: FIFO_CTRL,
+    _reserved7: [u8; 4usize],
+    #[doc = "0x40 - Eight bit mode"]
+    pub eight_bit_mode: EIGHT_BIT_MODE,
 }
-#[doc = "Dummy register: this peripheral is not implemented yet"]
-pub struct DUMMY {
+#[doc = "Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register"]
+pub struct LAYER_ARGUMENT_FIFO {
     register: ::vcell::VolatileCell<u32>,
 }
-#[doc = "Dummy register: this peripheral is not implemented yet"]
-pub mod dummy;
+#[doc = "Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register"]
+pub mod layer_argument_fifo;
+#[doc = "Interrupt status"]
+pub struct INTERRUPT_STATUS {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "Interrupt status"]
+pub mod interrupt_status;
+#[doc = "Interrupt raw"]
+pub struct INTERRUPT_RAW {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "Interrupt raw"]
+pub mod interrupt_raw;
+#[doc = "Interrupt mask: 0 enables the interrupt, 1 masks the interrupt"]
+pub struct INTERRUPT_MASK {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "Interrupt mask: 0 enables the interrupt, 1 masks the interrupt"]
+pub mod interrupt_mask;
+#[doc = "Interrupt clear: write 1 to a bit to clear interrupt"]
+pub struct INTERRUPT_CLEAR {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "Interrupt clear: write 1 to a bit to clear interrupt"]
+pub mod interrupt_clear;
+#[doc = "FIFO threshold"]
+pub struct FIFO_THRESHOLD {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "FIFO threshold"]
+pub mod fifo_threshold;
+#[doc = "FIFO data output"]
+pub struct FIFO_DATA_OUT {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "FIFO data output"]
+pub mod fifo_data_out;
+#[doc = "FIFO control"]
+pub struct FIFO_CTRL {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "FIFO control"]
+pub mod fifo_ctrl;
+#[doc = "Eight bit mode"]
+pub struct EIGHT_BIT_MODE {
+    register: ::vcell::VolatileCell<u32>,
+}
+#[doc = "Eight bit mode"]
+pub mod eight_bit_mode;

--- a/src/kpu.rs
+++ b/src/kpu.rs
@@ -3,82 +3,74 @@
 pub struct RegisterBlock {
     #[doc = "0x00 - Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register"]
     pub layer_argument_fifo: LAYER_ARGUMENT_FIFO,
-    _reserved0: [u8; 4usize],
     #[doc = "0x08 - Interrupt status"]
     pub interrupt_status: INTERRUPT_STATUS,
-    _reserved1: [u8; 4usize],
     #[doc = "0x10 - Interrupt raw"]
     pub interrupt_raw: INTERRUPT_RAW,
-    _reserved2: [u8; 4usize],
     #[doc = "0x18 - Interrupt mask: 0 enables the interrupt, 1 masks the interrupt"]
     pub interrupt_mask: INTERRUPT_MASK,
-    _reserved3: [u8; 4usize],
     #[doc = "0x20 - Interrupt clear: write 1 to a bit to clear interrupt"]
     pub interrupt_clear: INTERRUPT_CLEAR,
-    _reserved4: [u8; 4usize],
     #[doc = "0x28 - FIFO threshold"]
     pub fifo_threshold: FIFO_THRESHOLD,
-    _reserved5: [u8; 4usize],
     #[doc = "0x30 - FIFO data output"]
     pub fifo_data_out: FIFO_DATA_OUT,
-    _reserved6: [u8; 4usize],
     #[doc = "0x38 - FIFO control"]
     pub fifo_ctrl: FIFO_CTRL,
-    _reserved7: [u8; 4usize],
     #[doc = "0x40 - Eight bit mode"]
     pub eight_bit_mode: EIGHT_BIT_MODE,
 }
 #[doc = "Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register"]
 pub struct LAYER_ARGUMENT_FIFO {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "Layer arguments FIFO: each layer is defined by writing 12 successive argument values to this register"]
 pub mod layer_argument_fifo;
 #[doc = "Interrupt status"]
 pub struct INTERRUPT_STATUS {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "Interrupt status"]
 pub mod interrupt_status;
 #[doc = "Interrupt raw"]
 pub struct INTERRUPT_RAW {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "Interrupt raw"]
 pub mod interrupt_raw;
 #[doc = "Interrupt mask: 0 enables the interrupt, 1 masks the interrupt"]
 pub struct INTERRUPT_MASK {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "Interrupt mask: 0 enables the interrupt, 1 masks the interrupt"]
 pub mod interrupt_mask;
 #[doc = "Interrupt clear: write 1 to a bit to clear interrupt"]
 pub struct INTERRUPT_CLEAR {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "Interrupt clear: write 1 to a bit to clear interrupt"]
 pub mod interrupt_clear;
 #[doc = "FIFO threshold"]
 pub struct FIFO_THRESHOLD {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "FIFO threshold"]
 pub mod fifo_threshold;
 #[doc = "FIFO data output"]
 pub struct FIFO_DATA_OUT {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "FIFO data output"]
 pub mod fifo_data_out;
 #[doc = "FIFO control"]
 pub struct FIFO_CTRL {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "FIFO control"]
 pub mod fifo_ctrl;
 #[doc = "Eight bit mode"]
 pub struct EIGHT_BIT_MODE {
-    register: ::vcell::VolatileCell<u32>,
+    register: ::vcell::VolatileCell<u64>,
 }
 #[doc = "Eight bit mode"]
 pub mod eight_bit_mode;

--- a/src/kpu/eight_bit_mode.rs
+++ b/src/kpu/eight_bit_mode.rs
@@ -1,0 +1,123 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::EIGHT_BIT_MODE {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+#[doc = r" Value of the field"]
+pub struct EIGHT_BIT_MODER {
+    bits: bool,
+}
+impl EIGHT_BIT_MODER {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Proxy"]
+pub struct _EIGHT_BIT_MODEW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _EIGHT_BIT_MODEW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 0;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+    #[doc = "Bit 0 - Use 8-bit instead of 16-bit precision if set"]
+    #[inline]
+    pub fn eight_bit_mode(&self) -> EIGHT_BIT_MODER {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 0;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        EIGHT_BIT_MODER { bits }
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+    #[doc = "Bit 0 - Use 8-bit instead of 16-bit precision if set"]
+    #[inline]
+    pub fn eight_bit_mode(&mut self) -> _EIGHT_BIT_MODEW {
+        _EIGHT_BIT_MODEW { w: self }
+    }
+}

--- a/src/kpu/eight_bit_mode.rs
+++ b/src/kpu/eight_bit_mode.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::EIGHT_BIT_MODE {
     #[doc = r" Modifies the contents of the register"]
@@ -81,15 +81,15 @@ impl<'a> _EIGHT_BIT_MODEW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 0;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
     #[doc = "Bit 0 - Use 8-bit instead of 16-bit precision if set"]
@@ -98,7 +98,7 @@ impl R {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 0;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
         EIGHT_BIT_MODER { bits }
     }
@@ -111,7 +111,7 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }

--- a/src/kpu/fifo_ctrl.rs
+++ b/src/kpu/fifo_ctrl.rs
@@ -1,0 +1,359 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::FIFO_CTRL {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+#[doc = r" Value of the field"]
+pub struct DMA_FLUSHR {
+    bits: bool,
+}
+impl DMA_FLUSHR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Value of the field"]
+pub struct GS_FLUSHR {
+    bits: bool,
+}
+impl GS_FLUSHR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Value of the field"]
+pub struct CFG_FLUSHR {
+    bits: bool,
+}
+impl CFG_FLUSHR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Value of the field"]
+pub struct CMD_FLUSHR {
+    bits: bool,
+}
+impl CMD_FLUSHR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Value of the field"]
+pub struct RESP_FLUSHR {
+    bits: bool,
+}
+impl RESP_FLUSHR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Proxy"]
+pub struct _DMA_FLUSHW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _DMA_FLUSHW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 0;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+#[doc = r" Proxy"]
+pub struct _GS_FLUSHW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _GS_FLUSHW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 1;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+#[doc = r" Proxy"]
+pub struct _CFG_FLUSHW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _CFG_FLUSHW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 2;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+#[doc = r" Proxy"]
+pub struct _CMD_FLUSHW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _CMD_FLUSHW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 3;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+#[doc = r" Proxy"]
+pub struct _RESP_FLUSHW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _RESP_FLUSHW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 4;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+    #[doc = "Bit 0 - Flush DMA FIFO"]
+    #[inline]
+    pub fn dma_flush(&self) -> DMA_FLUSHR {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 0;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        DMA_FLUSHR { bits }
+    }
+    #[doc = "Bit 1 - Flush GS FIFO"]
+    #[inline]
+    pub fn gs_flush(&self) -> GS_FLUSHR {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 1;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        GS_FLUSHR { bits }
+    }
+    #[doc = "Bit 2 - Flush configuration FIFO"]
+    #[inline]
+    pub fn cfg_flush(&self) -> CFG_FLUSHR {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 2;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        CFG_FLUSHR { bits }
+    }
+    #[doc = "Bit 3 - Flush command FIFO"]
+    #[inline]
+    pub fn cmd_flush(&self) -> CMD_FLUSHR {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 3;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        CMD_FLUSHR { bits }
+    }
+    #[doc = "Bit 4 - Flush response FIFO"]
+    #[inline]
+    pub fn resp_flush(&self) -> RESP_FLUSHR {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 4;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        RESP_FLUSHR { bits }
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+    #[doc = "Bit 0 - Flush DMA FIFO"]
+    #[inline]
+    pub fn dma_flush(&mut self) -> _DMA_FLUSHW {
+        _DMA_FLUSHW { w: self }
+    }
+    #[doc = "Bit 1 - Flush GS FIFO"]
+    #[inline]
+    pub fn gs_flush(&mut self) -> _GS_FLUSHW {
+        _GS_FLUSHW { w: self }
+    }
+    #[doc = "Bit 2 - Flush configuration FIFO"]
+    #[inline]
+    pub fn cfg_flush(&mut self) -> _CFG_FLUSHW {
+        _CFG_FLUSHW { w: self }
+    }
+    #[doc = "Bit 3 - Flush command FIFO"]
+    #[inline]
+    pub fn cmd_flush(&mut self) -> _CMD_FLUSHW {
+        _CMD_FLUSHW { w: self }
+    }
+    #[doc = "Bit 4 - Flush response FIFO"]
+    #[inline]
+    pub fn resp_flush(&mut self) -> _RESP_FLUSHW {
+        _RESP_FLUSHW { w: self }
+    }
+}

--- a/src/kpu/fifo_ctrl.rs
+++ b/src/kpu/fifo_ctrl.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::FIFO_CTRL {
     #[doc = r" Modifies the contents of the register"]
@@ -43,10 +43,10 @@ impl super::FIFO_CTRL {
     }
 }
 #[doc = r" Value of the field"]
-pub struct DMA_FLUSHR {
+pub struct DMA_FIFO_FLUSH_NR {
     bits: bool,
 }
-impl DMA_FLUSHR {
+impl DMA_FIFO_FLUSH_NR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bit(&self) -> bool {
@@ -64,10 +64,10 @@ impl DMA_FLUSHR {
     }
 }
 #[doc = r" Value of the field"]
-pub struct GS_FLUSHR {
+pub struct GS_FIFO_FLUSH_NR {
     bits: bool,
 }
-impl GS_FLUSHR {
+impl GS_FIFO_FLUSH_NR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bit(&self) -> bool {
@@ -85,10 +85,10 @@ impl GS_FLUSHR {
     }
 }
 #[doc = r" Value of the field"]
-pub struct CFG_FLUSHR {
+pub struct CFG_FIFO_FLUSH_NR {
     bits: bool,
 }
-impl CFG_FLUSHR {
+impl CFG_FIFO_FLUSH_NR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bit(&self) -> bool {
@@ -106,10 +106,10 @@ impl CFG_FLUSHR {
     }
 }
 #[doc = r" Value of the field"]
-pub struct CMD_FLUSHR {
+pub struct CMD_FIFO_FLUSH_NR {
     bits: bool,
 }
-impl CMD_FLUSHR {
+impl CMD_FIFO_FLUSH_NR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bit(&self) -> bool {
@@ -127,10 +127,10 @@ impl CMD_FLUSHR {
     }
 }
 #[doc = r" Value of the field"]
-pub struct RESP_FLUSHR {
+pub struct RESP_FIFO_FLUSH_NR {
     bits: bool,
 }
-impl RESP_FLUSHR {
+impl RESP_FIFO_FLUSH_NR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bit(&self) -> bool {
@@ -148,10 +148,10 @@ impl RESP_FLUSHR {
     }
 }
 #[doc = r" Proxy"]
-pub struct _DMA_FLUSHW<'a> {
+pub struct _DMA_FIFO_FLUSH_NW<'a> {
     w: &'a mut W,
 }
-impl<'a> _DMA_FLUSHW<'a> {
+impl<'a> _DMA_FIFO_FLUSH_NW<'a> {
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
         self.bit(true)
@@ -165,16 +165,16 @@ impl<'a> _DMA_FLUSHW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 0;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 #[doc = r" Proxy"]
-pub struct _GS_FLUSHW<'a> {
+pub struct _GS_FIFO_FLUSH_NW<'a> {
     w: &'a mut W,
 }
-impl<'a> _GS_FLUSHW<'a> {
+impl<'a> _GS_FIFO_FLUSH_NW<'a> {
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
         self.bit(true)
@@ -188,16 +188,16 @@ impl<'a> _GS_FLUSHW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 1;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 #[doc = r" Proxy"]
-pub struct _CFG_FLUSHW<'a> {
+pub struct _CFG_FIFO_FLUSH_NW<'a> {
     w: &'a mut W,
 }
-impl<'a> _CFG_FLUSHW<'a> {
+impl<'a> _CFG_FIFO_FLUSH_NW<'a> {
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
         self.bit(true)
@@ -211,16 +211,16 @@ impl<'a> _CFG_FLUSHW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 2;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 #[doc = r" Proxy"]
-pub struct _CMD_FLUSHW<'a> {
+pub struct _CMD_FIFO_FLUSH_NW<'a> {
     w: &'a mut W,
 }
-impl<'a> _CMD_FLUSHW<'a> {
+impl<'a> _CMD_FIFO_FLUSH_NW<'a> {
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
         self.bit(true)
@@ -234,16 +234,16 @@ impl<'a> _CMD_FLUSHW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 3;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 #[doc = r" Proxy"]
-pub struct _RESP_FLUSHW<'a> {
+pub struct _RESP_FIFO_FLUSH_NW<'a> {
     w: &'a mut W,
 }
-impl<'a> _RESP_FLUSHW<'a> {
+impl<'a> _RESP_FIFO_FLUSH_NW<'a> {
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
         self.bit(true)
@@ -257,66 +257,66 @@ impl<'a> _RESP_FLUSHW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 4;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
     #[doc = "Bit 0 - Flush DMA FIFO"]
     #[inline]
-    pub fn dma_flush(&self) -> DMA_FLUSHR {
+    pub fn dma_fifo_flush_n(&self) -> DMA_FIFO_FLUSH_NR {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 0;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
-        DMA_FLUSHR { bits }
+        DMA_FIFO_FLUSH_NR { bits }
     }
     #[doc = "Bit 1 - Flush GS FIFO"]
     #[inline]
-    pub fn gs_flush(&self) -> GS_FLUSHR {
+    pub fn gs_fifo_flush_n(&self) -> GS_FIFO_FLUSH_NR {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 1;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
-        GS_FLUSHR { bits }
+        GS_FIFO_FLUSH_NR { bits }
     }
     #[doc = "Bit 2 - Flush configuration FIFO"]
     #[inline]
-    pub fn cfg_flush(&self) -> CFG_FLUSHR {
+    pub fn cfg_fifo_flush_n(&self) -> CFG_FIFO_FLUSH_NR {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 2;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
-        CFG_FLUSHR { bits }
+        CFG_FIFO_FLUSH_NR { bits }
     }
     #[doc = "Bit 3 - Flush command FIFO"]
     #[inline]
-    pub fn cmd_flush(&self) -> CMD_FLUSHR {
+    pub fn cmd_fifo_flush_n(&self) -> CMD_FIFO_FLUSH_NR {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 3;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
-        CMD_FLUSHR { bits }
+        CMD_FIFO_FLUSH_NR { bits }
     }
     #[doc = "Bit 4 - Flush response FIFO"]
     #[inline]
-    pub fn resp_flush(&self) -> RESP_FLUSHR {
+    pub fn resp_fifo_flush_n(&self) -> RESP_FIFO_FLUSH_NR {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 4;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
-        RESP_FLUSHR { bits }
+        RESP_FIFO_FLUSH_NR { bits }
     }
 }
 impl W {
@@ -327,33 +327,33 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }
     #[doc = "Bit 0 - Flush DMA FIFO"]
     #[inline]
-    pub fn dma_flush(&mut self) -> _DMA_FLUSHW {
-        _DMA_FLUSHW { w: self }
+    pub fn dma_fifo_flush_n(&mut self) -> _DMA_FIFO_FLUSH_NW {
+        _DMA_FIFO_FLUSH_NW { w: self }
     }
     #[doc = "Bit 1 - Flush GS FIFO"]
     #[inline]
-    pub fn gs_flush(&mut self) -> _GS_FLUSHW {
-        _GS_FLUSHW { w: self }
+    pub fn gs_fifo_flush_n(&mut self) -> _GS_FIFO_FLUSH_NW {
+        _GS_FIFO_FLUSH_NW { w: self }
     }
     #[doc = "Bit 2 - Flush configuration FIFO"]
     #[inline]
-    pub fn cfg_flush(&mut self) -> _CFG_FLUSHW {
-        _CFG_FLUSHW { w: self }
+    pub fn cfg_fifo_flush_n(&mut self) -> _CFG_FIFO_FLUSH_NW {
+        _CFG_FIFO_FLUSH_NW { w: self }
     }
     #[doc = "Bit 3 - Flush command FIFO"]
     #[inline]
-    pub fn cmd_flush(&mut self) -> _CMD_FLUSHW {
-        _CMD_FLUSHW { w: self }
+    pub fn cmd_fifo_flush_n(&mut self) -> _CMD_FIFO_FLUSH_NW {
+        _CMD_FIFO_FLUSH_NW { w: self }
     }
     #[doc = "Bit 4 - Flush response FIFO"]
     #[inline]
-    pub fn resp_flush(&mut self) -> _RESP_FLUSHW {
-        _RESP_FLUSHW { w: self }
+    pub fn resp_fifo_flush_n(&mut self) -> _RESP_FIFO_FLUSH_NW {
+        _RESP_FIFO_FLUSH_NW { w: self }
     }
 }

--- a/src/kpu/fifo_data_out.rs
+++ b/src/kpu/fifo_data_out.rs
@@ -1,0 +1,64 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::FIFO_DATA_OUT {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}

--- a/src/kpu/fifo_data_out.rs
+++ b/src/kpu/fifo_data_out.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::FIFO_DATA_OUT {
     #[doc = r" Modifies the contents of the register"]
@@ -45,7 +45,7 @@ impl super::FIFO_DATA_OUT {
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
 }
@@ -57,7 +57,7 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }

--- a/src/kpu/fifo_threshold.rs
+++ b/src/kpu/fifo_threshold.rs
@@ -1,0 +1,146 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::FIFO_THRESHOLD {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+#[doc = r" Value of the field"]
+pub struct FULLR {
+    bits: u8,
+}
+impl FULLR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u8 {
+        self.bits
+    }
+}
+#[doc = r" Value of the field"]
+pub struct EMPTYR {
+    bits: u8,
+}
+impl EMPTYR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u8 {
+        self.bits
+    }
+}
+#[doc = r" Proxy"]
+pub struct _FULLW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _FULLW<'a> {
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        const MASK: u8 = 15;
+        const OFFSET: u8 = 0;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+#[doc = r" Proxy"]
+pub struct _EMPTYW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _EMPTYW<'a> {
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        const MASK: u8 = 15;
+        const OFFSET: u8 = 4;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+    #[doc = "Bits 0:3 - FIFO full threshold"]
+    #[inline]
+    pub fn full(&self) -> FULLR {
+        let bits = {
+            const MASK: u8 = 15;
+            const OFFSET: u8 = 0;
+            ((self.bits >> OFFSET) & MASK as u32) as u8
+        };
+        FULLR { bits }
+    }
+    #[doc = "Bits 4:7 - FIFO empty threshold"]
+    #[inline]
+    pub fn empty(&self) -> EMPTYR {
+        let bits = {
+            const MASK: u8 = 15;
+            const OFFSET: u8 = 4;
+            ((self.bits >> OFFSET) & MASK as u32) as u8
+        };
+        EMPTYR { bits }
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+    #[doc = "Bits 0:3 - FIFO full threshold"]
+    #[inline]
+    pub fn full(&mut self) -> _FULLW {
+        _FULLW { w: self }
+    }
+    #[doc = "Bits 4:7 - FIFO empty threshold"]
+    #[inline]
+    pub fn empty(&mut self) -> _EMPTYW {
+        _EMPTYW { w: self }
+    }
+}

--- a/src/kpu/fifo_threshold.rs
+++ b/src/kpu/fifo_threshold.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::FIFO_THRESHOLD {
     #[doc = r" Modifies the contents of the register"]
@@ -43,10 +43,10 @@ impl super::FIFO_THRESHOLD {
     }
 }
 #[doc = r" Value of the field"]
-pub struct FULLR {
+pub struct FULL_THRESHOLDR {
     bits: u8,
 }
-impl FULLR {
+impl FULL_THRESHOLDR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
@@ -54,10 +54,10 @@ impl FULLR {
     }
 }
 #[doc = r" Value of the field"]
-pub struct EMPTYR {
+pub struct EMPTY_THRESHOLDR {
     bits: u8,
 }
-impl EMPTYR {
+impl EMPTY_THRESHOLDR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
@@ -65,60 +65,60 @@ impl EMPTYR {
     }
 }
 #[doc = r" Proxy"]
-pub struct _FULLW<'a> {
+pub struct _FULL_THRESHOLDW<'a> {
     w: &'a mut W,
 }
-impl<'a> _FULLW<'a> {
+impl<'a> _FULL_THRESHOLDW<'a> {
     #[doc = r" Writes raw bits to the field"]
     #[inline]
     pub unsafe fn bits(self, value: u8) -> &'a mut W {
         const MASK: u8 = 15;
         const OFFSET: u8 = 0;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 #[doc = r" Proxy"]
-pub struct _EMPTYW<'a> {
+pub struct _EMPTY_THRESHOLDW<'a> {
     w: &'a mut W,
 }
-impl<'a> _EMPTYW<'a> {
+impl<'a> _EMPTY_THRESHOLDW<'a> {
     #[doc = r" Writes raw bits to the field"]
     #[inline]
     pub unsafe fn bits(self, value: u8) -> &'a mut W {
         const MASK: u8 = 15;
         const OFFSET: u8 = 4;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
     #[doc = "Bits 0:3 - FIFO full threshold"]
     #[inline]
-    pub fn full(&self) -> FULLR {
+    pub fn full_threshold(&self) -> FULL_THRESHOLDR {
         let bits = {
             const MASK: u8 = 15;
             const OFFSET: u8 = 0;
-            ((self.bits >> OFFSET) & MASK as u32) as u8
+            ((self.bits >> OFFSET) & MASK as u64) as u8
         };
-        FULLR { bits }
+        FULL_THRESHOLDR { bits }
     }
     #[doc = "Bits 4:7 - FIFO empty threshold"]
     #[inline]
-    pub fn empty(&self) -> EMPTYR {
+    pub fn empty_threshold(&self) -> EMPTY_THRESHOLDR {
         let bits = {
             const MASK: u8 = 15;
             const OFFSET: u8 = 4;
-            ((self.bits >> OFFSET) & MASK as u32) as u8
+            ((self.bits >> OFFSET) & MASK as u64) as u8
         };
-        EMPTYR { bits }
+        EMPTY_THRESHOLDR { bits }
     }
 }
 impl W {
@@ -129,18 +129,18 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }
     #[doc = "Bits 0:3 - FIFO full threshold"]
     #[inline]
-    pub fn full(&mut self) -> _FULLW {
-        _FULLW { w: self }
+    pub fn full_threshold(&mut self) -> _FULL_THRESHOLDW {
+        _FULL_THRESHOLDW { w: self }
     }
     #[doc = "Bits 4:7 - FIFO empty threshold"]
     #[inline]
-    pub fn empty(&mut self) -> _EMPTYW {
-        _EMPTYW { w: self }
+    pub fn empty_threshold(&mut self) -> _EMPTY_THRESHOLDW {
+        _EMPTY_THRESHOLDW { w: self }
     }
 }

--- a/src/kpu/interrupt_clear.rs
+++ b/src/kpu/interrupt_clear.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::INTERRUPT_CLEAR {
     #[doc = r" Modifies the contents of the register"]
@@ -45,7 +45,7 @@ impl super::INTERRUPT_CLEAR {
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
 }
@@ -57,7 +57,7 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }

--- a/src/kpu/interrupt_clear.rs
+++ b/src/kpu/interrupt_clear.rs
@@ -6,7 +6,7 @@ pub struct R {
 pub struct W {
     bits: u32,
 }
-impl super::DUMMY {
+impl super::INTERRUPT_CLEAR {
     #[doc = r" Modifies the contents of the register"]
     #[inline]
     pub fn modify<F>(&self, f: F)

--- a/src/kpu/interrupt_mask.rs
+++ b/src/kpu/interrupt_mask.rs
@@ -1,0 +1,64 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::INTERRUPT_MASK {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}

--- a/src/kpu/interrupt_mask.rs
+++ b/src/kpu/interrupt_mask.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::INTERRUPT_MASK {
     #[doc = r" Modifies the contents of the register"]
@@ -45,7 +45,7 @@ impl super::INTERRUPT_MASK {
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
 }
@@ -57,7 +57,7 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }

--- a/src/kpu/interrupt_raw.rs
+++ b/src/kpu/interrupt_raw.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::INTERRUPT_RAW {
     #[doc = r" Modifies the contents of the register"]
@@ -45,7 +45,7 @@ impl super::INTERRUPT_RAW {
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
 }
@@ -57,7 +57,7 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }

--- a/src/kpu/interrupt_raw.rs
+++ b/src/kpu/interrupt_raw.rs
@@ -1,0 +1,64 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::INTERRUPT_RAW {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}

--- a/src/kpu/interrupt_status.rs
+++ b/src/kpu/interrupt_status.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::INTERRUPT_STATUS {
     #[doc = r" Modifies the contents of the register"]
@@ -123,8 +123,8 @@ impl<'a> _CALC_DONEW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 0;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
@@ -146,8 +146,8 @@ impl<'a> _LAYER_CFG_ALMOST_EMPTYW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 1;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
@@ -169,15 +169,15 @@ impl<'a> _LAYER_CFG_ALMOST_FULLW<'a> {
     pub fn bit(self, value: bool) -> &'a mut W {
         const MASK: bool = true;
         const OFFSET: u8 = 2;
-        self.w.bits &= !((MASK as u32) << OFFSET);
-        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w.bits &= !((MASK as u64) << OFFSET);
+        self.w.bits |= ((value & MASK) as u64) << OFFSET;
         self.w
     }
 }
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
     #[doc = "Bit 0 - Interrupt raised when calculation is done"]
@@ -186,7 +186,7 @@ impl R {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 0;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
         CALC_DONER { bits }
     }
@@ -196,7 +196,7 @@ impl R {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 1;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
         LAYER_CFG_ALMOST_EMPTYR { bits }
     }
@@ -206,7 +206,7 @@ impl R {
         let bits = {
             const MASK: bool = true;
             const OFFSET: u8 = 2;
-            ((self.bits >> OFFSET) & MASK as u32) != 0
+            ((self.bits >> OFFSET) & MASK as u64) != 0
         };
         LAYER_CFG_ALMOST_FULLR { bits }
     }
@@ -219,7 +219,7 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }

--- a/src/kpu/interrupt_status.rs
+++ b/src/kpu/interrupt_status.rs
@@ -1,0 +1,241 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::INTERRUPT_STATUS {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+#[doc = r" Value of the field"]
+pub struct CALC_DONER {
+    bits: bool,
+}
+impl CALC_DONER {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Value of the field"]
+pub struct LAYER_CFG_ALMOST_EMPTYR {
+    bits: bool,
+}
+impl LAYER_CFG_ALMOST_EMPTYR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Value of the field"]
+pub struct LAYER_CFG_ALMOST_FULLR {
+    bits: bool,
+}
+impl LAYER_CFG_ALMOST_FULLR {
+    #[doc = r" Value of the field as raw bits"]
+    #[inline]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = r" Returns `true` if the bit is clear (0)"]
+    #[inline]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = r" Returns `true` if the bit is set (1)"]
+    #[inline]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = r" Proxy"]
+pub struct _CALC_DONEW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _CALC_DONEW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 0;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+#[doc = r" Proxy"]
+pub struct _LAYER_CFG_ALMOST_EMPTYW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _LAYER_CFG_ALMOST_EMPTYW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 1;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+#[doc = r" Proxy"]
+pub struct _LAYER_CFG_ALMOST_FULLW<'a> {
+    w: &'a mut W,
+}
+impl<'a> _LAYER_CFG_ALMOST_FULLW<'a> {
+    #[doc = r" Sets the field bit"]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r" Clears the field bit"]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r" Writes raw bits to the field"]
+    #[inline]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        const MASK: bool = true;
+        const OFFSET: u8 = 2;
+        self.w.bits &= !((MASK as u32) << OFFSET);
+        self.w.bits |= ((value & MASK) as u32) << OFFSET;
+        self.w
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+    #[doc = "Bit 0 - Interrupt raised when calculation is done"]
+    #[inline]
+    pub fn calc_done(&self) -> CALC_DONER {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 0;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        CALC_DONER { bits }
+    }
+    #[doc = "Bit 1 - Interrupt raised when layer arguments FIFO almost empty"]
+    #[inline]
+    pub fn layer_cfg_almost_empty(&self) -> LAYER_CFG_ALMOST_EMPTYR {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 1;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        LAYER_CFG_ALMOST_EMPTYR { bits }
+    }
+    #[doc = "Bit 2 - Interrupt raised when layer arguments FIFO almost full"]
+    #[inline]
+    pub fn layer_cfg_almost_full(&self) -> LAYER_CFG_ALMOST_FULLR {
+        let bits = {
+            const MASK: bool = true;
+            const OFFSET: u8 = 2;
+            ((self.bits >> OFFSET) & MASK as u32) != 0
+        };
+        LAYER_CFG_ALMOST_FULLR { bits }
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+    #[doc = "Bit 0 - Interrupt raised when calculation is done"]
+    #[inline]
+    pub fn calc_done(&mut self) -> _CALC_DONEW {
+        _CALC_DONEW { w: self }
+    }
+    #[doc = "Bit 1 - Interrupt raised when layer arguments FIFO almost empty"]
+    #[inline]
+    pub fn layer_cfg_almost_empty(&mut self) -> _LAYER_CFG_ALMOST_EMPTYW {
+        _LAYER_CFG_ALMOST_EMPTYW { w: self }
+    }
+    #[doc = "Bit 2 - Interrupt raised when layer arguments FIFO almost full"]
+    #[inline]
+    pub fn layer_cfg_almost_full(&mut self) -> _LAYER_CFG_ALMOST_FULLW {
+        _LAYER_CFG_ALMOST_FULLW { w: self }
+    }
+}

--- a/src/kpu/layer_argument_fifo.rs
+++ b/src/kpu/layer_argument_fifo.rs
@@ -1,10 +1,10 @@
 #[doc = r" Value read from the register"]
 pub struct R {
-    bits: u32,
+    bits: u64,
 }
 #[doc = r" Value to write to the register"]
 pub struct W {
-    bits: u32,
+    bits: u64,
 }
 impl super::LAYER_ARGUMENT_FIFO {
     #[doc = r" Modifies the contents of the register"]
@@ -45,7 +45,7 @@ impl super::LAYER_ARGUMENT_FIFO {
 impl R {
     #[doc = r" Value of the register as raw bits"]
     #[inline]
-    pub fn bits(&self) -> u32 {
+    pub fn bits(&self) -> u64 {
         self.bits
     }
 }
@@ -57,7 +57,7 @@ impl W {
     }
     #[doc = r" Writes raw bits to the register"]
     #[inline]
-    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+    pub unsafe fn bits(&mut self, bits: u64) -> &mut Self {
         self.bits = bits;
         self
     }

--- a/src/kpu/layer_argument_fifo.rs
+++ b/src/kpu/layer_argument_fifo.rs
@@ -1,0 +1,64 @@
+#[doc = r" Value read from the register"]
+pub struct R {
+    bits: u32,
+}
+#[doc = r" Value to write to the register"]
+pub struct W {
+    bits: u32,
+}
+impl super::LAYER_ARGUMENT_FIFO {
+    #[doc = r" Modifies the contents of the register"]
+    #[inline]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W,
+    {
+        let bits = self.register.get();
+        let r = R { bits: bits };
+        let mut w = W { bits: bits };
+        f(&r, &mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Reads the contents of the register"]
+    #[inline]
+    pub fn read(&self) -> R {
+        R {
+            bits: self.register.get(),
+        }
+    }
+    #[doc = r" Writes to the register"]
+    #[inline]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W) -> &mut W,
+    {
+        let mut w = W::reset_value();
+        f(&mut w);
+        self.register.set(w.bits);
+    }
+    #[doc = r" Writes the reset value to the register"]
+    #[inline]
+    pub fn reset(&self) {
+        self.write(|w| w)
+    }
+}
+impl R {
+    #[doc = r" Value of the register as raw bits"]
+    #[inline]
+    pub fn bits(&self) -> u32 {
+        self.bits
+    }
+}
+impl W {
+    #[doc = r" Reset value of the register"]
+    #[inline]
+    pub fn reset_value() -> W {
+        W { bits: 0 }
+    }
+    #[doc = r" Writes raw bits to the register"]
+    #[inline]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}


### PR DESCRIPTION
Add KPU (registers from `src/drivers/include/kpu.h` in Kendryte SDK)

Note: it looks like `svd2rust` is ignoring the 64-bit register size (will have the same problem with `DMAC` and `FFT`).