### PR TITLE
SPI: remove incorrect constraint for addr length

### DIFF
--- a/k210.svd
+++ b/k210.svd
@@ -1246,7 +1246,6 @@
                             <name>addr_length</name>
                             <description>ADDR_LENGTH</description>
                             <bitRange>[5:2]</bitRange>
-                            <writeConstraint><range><minimum>0</minimum><maximum>3</maximum></range></writeConstraint>
                         </field>
                         <field>
                             <name>inst_length</name>
@@ -1620,7 +1619,6 @@
                             <name>addr_length</name>
                             <description>ADDR_LENGTH</description>
                             <bitRange>[5:2]</bitRange>
-                            <writeConstraint><range><minimum>0</minimum><maximum>3</maximum></range></writeConstraint>
                         </field>
                         <field>
                             <name>inst_length</name>


### PR DESCRIPTION
Address length is 0..60 according to the [configASSERT](https://github.com/kendryte/kendryte-standalone-sdk/blob/develop/lib/drivers/spi.c#L218), the value is in 4-bit units so the value can be 0..15 which covers all values for these four bits.

Edit: though thinking of it, if there is a practical constraint it's probably `0..8`, it looks like the maximum transfer unit is 32 bits in practice, no idea how it could handle 64.