### PR TITLE
PLIC: s/enumerateValue/enumeratedValue

### DIFF
--- a/k210.svd
+++ b/k210.svd
@@ -85,46 +85,46 @@
                                 <msb>2</msb><lsb>0</lsb>
                                 <enumeratedValues>
                                     <name>Priority</name>
-                                    <enumerateValue>
+                                    <enumeratedValue>
                                         <name>Never</name>
                                         <description>Never interrupt</description>
                                         <value>0</value>
-                                    </enumerateValue>
-                                    <enumerateValue>
+                                    </enumeratedValue>
+                                    <enumeratedValue>
                                         <name>P1</name>
                                         <description>Priority 1</description>
                                         <value>1</value>
-                                    </enumerateValue>
-                                    <enumerateValue>
+                                    </enumeratedValue>
+                                    <enumeratedValue>
                                         <name>P2</name>
                                         <description>Priority 2</description>
                                         <value>2</value>
-                                    </enumerateValue>
-                                    <enumerateValue>
+                                    </enumeratedValue>
+                                    <enumeratedValue>
                                         <name>P3</name>
                                         <description>Priority 3</description>
                                         <value>3</value>
-                                    </enumerateValue>
-                                    <enumerateValue>
+                                    </enumeratedValue>
+                                    <enumeratedValue>
                                         <name>P4</name>
                                         <description>Priority 4</description>
                                         <value>4</value>
-                                    </enumerateValue>
-                                    <enumerateValue>
+                                    </enumeratedValue>
+                                    <enumeratedValue>
                                         <name>P5</name>
                                         <description>Priority 5</description>
                                         <value>5</value>
-                                    </enumerateValue>
-                                    <enumerateValue>
+                                    </enumeratedValue>
+                                    <enumeratedValue>
                                         <name>P6</name>
                                         <description>Priority 6</description>
                                         <value>6</value>
-                                    </enumerateValue>
-                                    <enumerateValue>
+                                    </enumeratedValue>
+                                    <enumeratedValue>
                                         <name>P7</name>
                                         <description>Priority 7</description>
                                         <value>7</value>
-                                    </enumerateValue>
+                                    </enumeratedValue>
                                 </enumeratedValues>
                             </field>
                         </fields>

--- a/src/plic/targets/threshold.rs
+++ b/src/plic/targets/threshold.rs
@@ -45,15 +45,36 @@ impl super::THRESHOLD {
 #[doc = "Possible values of the field `priority`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PRIORITYR {
-    #[doc = r" Reserved"]
-    _Reserved(u8),
+    #[doc = "Never interrupt"]
+    NEVER,
+    #[doc = "Priority 1"]
+    P1,
+    #[doc = "Priority 2"]
+    P2,
+    #[doc = "Priority 3"]
+    P3,
+    #[doc = "Priority 4"]
+    P4,
+    #[doc = "Priority 5"]
+    P5,
+    #[doc = "Priority 6"]
+    P6,
+    #[doc = "Priority 7"]
+    P7,
 }
 impl PRIORITYR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            PRIORITYR::_Reserved(bits) => bits,
+            PRIORITYR::NEVER => 0,
+            PRIORITYR::P1 => 1,
+            PRIORITYR::P2 => 2,
+            PRIORITYR::P3 => 3,
+            PRIORITYR::P4 => 4,
+            PRIORITYR::P5 => 5,
+            PRIORITYR::P6 => 6,
+            PRIORITYR::P7 => 7,
         }
     }
     #[allow(missing_docs)]
@@ -61,19 +82,93 @@ impl PRIORITYR {
     #[inline]
     pub fn _from(value: u8) -> PRIORITYR {
         match value {
-            i => PRIORITYR::_Reserved(i),
+            0 => PRIORITYR::NEVER,
+            1 => PRIORITYR::P1,
+            2 => PRIORITYR::P2,
+            3 => PRIORITYR::P3,
+            4 => PRIORITYR::P4,
+            5 => PRIORITYR::P5,
+            6 => PRIORITYR::P6,
+            7 => PRIORITYR::P7,
+            _ => unreachable!(),
         }
+    }
+    #[doc = "Checks if the value of the field is `NEVER`"]
+    #[inline]
+    pub fn is_never(&self) -> bool {
+        *self == PRIORITYR::NEVER
+    }
+    #[doc = "Checks if the value of the field is `P1`"]
+    #[inline]
+    pub fn is_p1(&self) -> bool {
+        *self == PRIORITYR::P1
+    }
+    #[doc = "Checks if the value of the field is `P2`"]
+    #[inline]
+    pub fn is_p2(&self) -> bool {
+        *self == PRIORITYR::P2
+    }
+    #[doc = "Checks if the value of the field is `P3`"]
+    #[inline]
+    pub fn is_p3(&self) -> bool {
+        *self == PRIORITYR::P3
+    }
+    #[doc = "Checks if the value of the field is `P4`"]
+    #[inline]
+    pub fn is_p4(&self) -> bool {
+        *self == PRIORITYR::P4
+    }
+    #[doc = "Checks if the value of the field is `P5`"]
+    #[inline]
+    pub fn is_p5(&self) -> bool {
+        *self == PRIORITYR::P5
+    }
+    #[doc = "Checks if the value of the field is `P6`"]
+    #[inline]
+    pub fn is_p6(&self) -> bool {
+        *self == PRIORITYR::P6
+    }
+    #[doc = "Checks if the value of the field is `P7`"]
+    #[inline]
+    pub fn is_p7(&self) -> bool {
+        *self == PRIORITYR::P7
     }
 }
 #[doc = "Values that can be written to the field `priority`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum PRIORITYW {}
+pub enum PRIORITYW {
+    #[doc = "Never interrupt"]
+    NEVER,
+    #[doc = "Priority 1"]
+    P1,
+    #[doc = "Priority 2"]
+    P2,
+    #[doc = "Priority 3"]
+    P3,
+    #[doc = "Priority 4"]
+    P4,
+    #[doc = "Priority 5"]
+    P5,
+    #[doc = "Priority 6"]
+    P6,
+    #[doc = "Priority 7"]
+    P7,
+}
 impl PRIORITYW {
     #[allow(missing_docs)]
     #[doc(hidden)]
     #[inline]
     pub fn _bits(&self) -> u8 {
-        match *self {}
+        match *self {
+            PRIORITYW::NEVER => 0,
+            PRIORITYW::P1 => 1,
+            PRIORITYW::P2 => 2,
+            PRIORITYW::P3 => 3,
+            PRIORITYW::P4 => 4,
+            PRIORITYW::P5 => 5,
+            PRIORITYW::P6 => 6,
+            PRIORITYW::P7 => 7,
+        }
     }
 }
 #[doc = r" Proxy"]
@@ -84,11 +179,53 @@ impl<'a> _PRIORITYW<'a> {
     #[doc = r" Writes `variant` to the field"]
     #[inline]
     pub fn variant(self, variant: PRIORITYW) -> &'a mut W {
-        unsafe { self.bits(variant._bits()) }
+        {
+            self.bits(variant._bits())
+        }
+    }
+    #[doc = "Never interrupt"]
+    #[inline]
+    pub fn never(self) -> &'a mut W {
+        self.variant(PRIORITYW::NEVER)
+    }
+    #[doc = "Priority 1"]
+    #[inline]
+    pub fn p1(self) -> &'a mut W {
+        self.variant(PRIORITYW::P1)
+    }
+    #[doc = "Priority 2"]
+    #[inline]
+    pub fn p2(self) -> &'a mut W {
+        self.variant(PRIORITYW::P2)
+    }
+    #[doc = "Priority 3"]
+    #[inline]
+    pub fn p3(self) -> &'a mut W {
+        self.variant(PRIORITYW::P3)
+    }
+    #[doc = "Priority 4"]
+    #[inline]
+    pub fn p4(self) -> &'a mut W {
+        self.variant(PRIORITYW::P4)
+    }
+    #[doc = "Priority 5"]
+    #[inline]
+    pub fn p5(self) -> &'a mut W {
+        self.variant(PRIORITYW::P5)
+    }
+    #[doc = "Priority 6"]
+    #[inline]
+    pub fn p6(self) -> &'a mut W {
+        self.variant(PRIORITYW::P6)
+    }
+    #[doc = "Priority 7"]
+    #[inline]
+    pub fn p7(self) -> &'a mut W {
+        self.variant(PRIORITYW::P7)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
-    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+    pub fn bits(self, value: u8) -> &'a mut W {
         const MASK: u8 = 7;
         const OFFSET: u8 = 0;
         self.w.bits &= !((MASK as u32) << OFFSET);


### PR DESCRIPTION
Fix a typo causing enumeration values to be ignored by the parser.