### PR TITLE
Remove work-around for pcrel issue

### DIFF
--- a/memory-k210.x
+++ b/memory-k210.x
@@ -2,10 +2,8 @@ _max_hart_id = 1;
 
 MEMORY
 {
-    /* Workaround for the pcrel issue, as described here:
-       https://github.com/rust-embedded/riscv-rt/issues/25#issuecomment-491518168 */
-    SRAM : ORIGIN = 0xffffffff80000000, LENGTH = 6M
-    AI_SRAM : ORIGIN = 0xffffffff80600000, LENGTH = 2M
+    SRAM : ORIGIN = 0x80000000, LENGTH = 6M
+    AI_SRAM : ORIGIN = 0x80600000, LENGTH = 2M
     SRAM_NOCACHE : ORIGIN = 0x40000000, LENGTH = 6M
     AI_SRAM_NOCACHE : ORIGIN = 0x40600000, LENGTH = 2M
 }


### PR DESCRIPTION
With rust-lang/rust#62281, rust compiles in mcmodel=medium mode by default and this work-around is no longer needed.

I don't think this can be merged yet for the forseeable future, until the above is in stable, but I've tested this and it works!